### PR TITLE
Prepare for Lita 3.0

### DIFF
--- a/lita-down-for-everyone.gemspec
+++ b/lita-down-for-everyone.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "lita", "~> 2.5"
+  spec.add_runtime_dependency "lita"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"
-  spec.add_development_dependency "rspec", ">= 2.14"
+  spec.add_development_dependency "rspec", ">= 3.0.0.beta2"
 end


### PR DESCRIPTION
- Loosens lita version requirement
- Bumps Rspec to 3.0.0.beta2
- Seems not to break anything
